### PR TITLE
Use --format option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,11 +4,11 @@ AllCops:
 Metrics/AbcSize:
     Max: 23
 Metrics/BlockLength:
-    Max: 37
+    Max: 44
 Metrics/CyclomaticComplexity:
     Max: 6
 Metrics/MethodLength:
-    Max: 16
+    Max: 28
 Naming/MethodParameterName:
     Enabled: false
 Metrics/PerceivedComplexity:

--- a/README.md
+++ b/README.md
@@ -24,22 +24,38 @@ This application is neither affiliated with Two Factor Authentication Service, I
 ruby lib/decrypt.rb test/encrypted_test.2fas
 ```
 
-You should get the following plaintext output.
+You should get the following plaintext JSON output.
 
 ```json
 [{"name":"Deno","secret":"4SJHB4GSD43FZBAI7C2HLRJGPQ","updatedAt":1708958115316,"otp":{"label":"Mason","account":"Mason","issuer":"Deno","digits":6,"period":30,"algorithm":"SHA1","tokenType":"TOTP","source":"Link"},"order":{"position":0},"icon":{"selected":"Label","label":{"text":"DE","backgroundColor":"Brown"},"iconCollection":{"id":"a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad"}}},{"name":"SPDX","secret":"5OM4WOOGPLQEF6UGN3CPEOOLWU","updatedAt":1708958115348,"otp":{"label":"James","account":"James","issuer":"SPDX","digits":7,"period":30,"algorithm":"SHA256","tokenType":"TOTP","source":"Link"},"order":{"position":1},"icon":{"selected":"Label","label":{"text":"SP","backgroundColor":"Red"},"iconCollection":{"id":"a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad"}}},{"name":"Airbnb","secret":"7ELGJSGXNCCTV3O6LKJWYFV2RA","updatedAt":1708958115376,"otp":{"label":"Elijah","account":"Elijah","issuer":"Airbnb","digits":8,"period":60,"algorithm":"SHA512","tokenType":"TOTP","source":"Link"},"order":{"position":2},"icon":{"selected":"Label","label":{"text":"AI","backgroundColor":"Pink"},"iconCollection":{"id":"a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad"}}},{"name":"Boeing","secret":"JRZCL47CMXVOQMNPZR2F7J4RGI","updatedAt":1708958115391,"otp":{"label":"Sophia","account":"Sophia","issuer":"Boeing","digits":5,"period":10,"algorithm":"SHA1","tokenType":"STEAM","source":"Link"},"order":{"position":3},"icon":{"selected":"Label","label":{"text":"BO","backgroundColor":"Brown"},"iconCollection":{"id":"a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad"}}},{"name":"Air Canada","secret":"KUVJJOM753IHTNDSZVCNKL7GII","updatedAt":1708958401763,"otp":{"link":"otpauth://hotp/Benjamin?secret=KUVJJOM753IHTNDSZVCNKL7GII&issuer=Air%20Canada&counter=10&algorithm=SHA256&digits=8","label":"Benjamin","account":"Benjamin","issuer":"Air Canada","digits":8,"algorithm":"SHA256","counter":10,"tokenType":"HOTP","source":"Link"},"order":{"position":4},"icon":{"selected":"Label","label":{"text":"AI","backgroundColor":"Brown"},"iconCollection":{"id":"a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad"}}}]
 ```
 
-### Pretty output
+### Other formats
 
-You can also pretty print the plaintext output as a CSV-like String padded with spaces by running [lib/pretty.rb](lib/pretty.rb) instead.
+You can also add the `-f / --format` option to print the plaintext output as `csv` or as a `pretty` CSV-like String padded with spaces.
+
+#### csv
 
 ```bash
 # Enter the above password when prompted
-ruby lib/pretty.rb test/encrypted_test.2fas
+ruby lib/decrypt.rb test/encrypted_test.2fas -f csv
 ```
 
-Output
+```csv
+icon.iconCollection.id,icon.label.backgroundColor,icon.label.text,icon.selected,name,order.position,otp.account,otp.algorithm,otp.counter,otp.digits,otp.issuer,otp.label,otp.link,otp.period,otp.source,otp.tokenType,secret,updatedAt
+a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad,Brown,DE,Label,Deno,0,Mason,SHA1,,6,Deno,Mason,,30,Link,TOTP,4SJHB4GSD43FZBAI7C2HLRJGPQ,1708958115316
+a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad,Red,SP,Label,SPDX,1,James,SHA256,,7,SPDX,James,,30,Link,TOTP,5OM4WOOGPLQEF6UGN3CPEOOLWU,1708958115348
+a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad,Pink,AI,Label,Airbnb,2,Elijah,SHA512,,8,Airbnb,Elijah,,60,Link,TOTP,7ELGJSGXNCCTV3O6LKJWYFV2RA,1708958115376
+a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad,Brown,BO,Label,Boeing,3,Sophia,SHA1,,5,Boeing,Sophia,,10,Link,STEAM,JRZCL47CMXVOQMNPZR2F7J4RGI,1708958115391
+a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad,Brown,AI,Label,Air Canada,4,Benjamin,SHA256,10,8,Air Canada,Benjamin,otpauth://hotp/Benjamin?secret=KUVJJOM753IHTNDSZVCNKL7GII&issuer=Air%20Canada&counter=10&algorithm=SHA256&digits=8,,Link,HOTP,KUVJJOM753IHTNDSZVCNKL7GII,1708958401763
+```
+
+#### pretty
+
+```bash
+# Enter the above password when prompted
+ruby lib/decrypt.rb test/encrypted_test.2fas -f pretty
+```
 
 ```csv
 icon.iconCollection.id                icon.label.backgroundColor  icon.label.text  icon.selected  name        order.position  otp.account  otp.algorithm  otp.counter  otp.digits  otp.issuer  otp.label  otp.link                                                                                                            otp.period  otp.source  otp.tokenType  secret                      updatedAt

--- a/lib/pretty.rb
+++ b/lib/pretty.rb
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 require 'csv'
-require_relative 'decrypt'
 
 #
 # Recursively flatten a nested JSON object into a single-level hash
@@ -83,5 +82,3 @@ def beautify(raw_csv)
   end
   output
 end
-
-$stdout.write beautify entries_to_csv decrypt_vault if __FILE__ == $PROGRAM_NAME

--- a/spec/decrypt_spec.rb
+++ b/spec/decrypt_spec.rb
@@ -17,12 +17,15 @@
 require 'spec_helper'
 require 'decrypt'
 
+ENCRYPTED_TEST_VAULT = 'test/encrypted_test.2fas'.freeze
+
 # See https://michaelay.github.io/blog/2014/12/15/suppress-stdout-and-stderr-when-running-rspec
-def silence
+def silence(filter = '')
   @original_stderr = $stderr
   @original_stdout = $stdout
 
-  $stderr = $stdout = StringIO.new
+  $stderr = StringIO.new if filter != 'stdout'
+  $stdout = StringIO.new if filter != 'stderr'
 
   yield
 
@@ -81,26 +84,35 @@ describe 'extract_fields' do
   end
 end
 
+def decryption_test(args, expected_plaintext_filename)
+  ARGV.replace args
+  allow($stdin).to receive(:noecho) { 'example.com' } # Backup file password
+  output = nil
+  expect($stdout).to receive(:write) { |arg| output = arg }
+  silence('stderr') do
+    main
+  end
+  expected_plaintext_vault = File.read(expected_plaintext_filename, :encoding => 'utf-8')
+  expect(output).to eq expected_plaintext_vault
+end
+
 describe 'main' do
   it 'Correct password -> Decryption success' do
-    ARGV.replace ['test/encrypted_test.2fas']
-    allow($stdin).to receive(:noecho) { 'example.com' } # Backup file password
-    output = nil
-    expect($stderr).to receive(:puts)
-    expect($stdout).to receive(:write) { |arg| output = arg }
-    main
-    expected_plaintext_vault = File.read('test/plaintext_test.json', :encoding => 'utf-8')
-    expect(output).to eq expected_plaintext_vault
+    ['-f', '--format'].each do |flag|
+      decryption_test([ENCRYPTED_TEST_VAULT, flag, 'json'], 'test/plaintext_test.json')
+      decryption_test([ENCRYPTED_TEST_VAULT, flag, 'csv'], 'test/csv_test.csv')
+      decryption_test([ENCRYPTED_TEST_VAULT, flag, 'pretty'], 'test/pretty_test.txt')
+    end
   end
   it 'Wrong password -> Decryption failure' do
-    ARGV.replace ['test/encrypted_test.2fas']
+    ARGV.replace [ENCRYPTED_TEST_VAULT]
     allow($stdin).to receive(:noecho) { '' }
     expect { main }.to raise_error(SystemExit) do |error|
       expect(error.status).to eq(1)
     end
   end
   it 'No such file or directory -> SystemExit' do
-    ARGV.replace ['test/encrypted_test_that_does_not_exist.json']
+    ARGV.replace ["#{ENCRYPTED_TEST_VAULT}_that_does_not_exist"]
     allow($stdin).to receive(:noecho) { '' }
     silence do
       expect { main }.to raise_error(SystemExit) do |error|
@@ -109,7 +121,7 @@ describe 'main' do
     end
   end
   it 'Accepts exactly 1 argument' do
-    test_vectors = [[], ['test/encrypted_test.2fas', 'another'], ['test/encrypted_test.2fas', 'yet another']]
+    test_vectors = [[], [ENCRYPTED_TEST_VAULT, 'another'], [ENCRYPTED_TEST_VAULT, 'yet another']]
     silence do
       test_vectors.each do |args|
         ARGV.replace args
@@ -118,5 +130,14 @@ describe 'main' do
         end
       end
     end
+  end
+  it 'Shows help' do
+    ARGV.replace ['--help']
+    output = nil
+    expect($stdout).to receive(:write) { |arg| output = arg }
+    expect { main }.to raise_error(SystemExit) do |error|
+      expect(error.status).to eq(0)
+    end
+    expect(output.start_with?('Usage')).to eq true
   end
 end

--- a/test/csv_test.csv
+++ b/test/csv_test.csv
@@ -1,0 +1,6 @@
+icon.iconCollection.id,icon.label.backgroundColor,icon.label.text,icon.selected,name,order.position,otp.account,otp.algorithm,otp.counter,otp.digits,otp.issuer,otp.label,otp.link,otp.period,otp.source,otp.tokenType,secret,updatedAt
+a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad,Brown,DE,Label,Deno,0,Mason,SHA1,,6,Deno,Mason,,30,Link,TOTP,4SJHB4GSD43FZBAI7C2HLRJGPQ,1708958115316
+a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad,Red,SP,Label,SPDX,1,James,SHA256,,7,SPDX,James,,30,Link,TOTP,5OM4WOOGPLQEF6UGN3CPEOOLWU,1708958115348
+a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad,Pink,AI,Label,Airbnb,2,Elijah,SHA512,,8,Airbnb,Elijah,,60,Link,TOTP,7ELGJSGXNCCTV3O6LKJWYFV2RA,1708958115376
+a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad,Brown,BO,Label,Boeing,3,Sophia,SHA1,,5,Boeing,Sophia,,10,Link,STEAM,JRZCL47CMXVOQMNPZR2F7J4RGI,1708958115391
+a5b3fb65-4ec5-43e6-8ec1-49e24ca9e7ad,Brown,AI,Label,Air Canada,4,Benjamin,SHA256,10,8,Air Canada,Benjamin,otpauth://hotp/Benjamin?secret=KUVJJOM753IHTNDSZVCNKL7GII&issuer=Air%20Canada&counter=10&algorithm=SHA256&digits=8,,Link,HOTP,KUVJJOM753IHTNDSZVCNKL7GII,1708958401763


### PR DESCRIPTION
### Changes

- Plain CSV output is now also supported via the `-f / --format` option, in addition to JSON and Pretty formats.
- Support for running `lib/pretty.rb` directly has been dropped.